### PR TITLE
fix the event reason

### DIFF
--- a/src/controller/controller.go
+++ b/src/controller/controller.go
@@ -100,7 +100,7 @@ func (c *Controller) evaluatePodStatus(pod *corev1_api.Pod) {
 
 		if c.setRestartCount(string(pod.UID), s.ContainerID, s.RestartCount) {
 			glog.V(1).Infof("The container '%s' in '%s/%s' was restarted for the %d time", s.Name, pod.Namespace, pod.Name, s.RestartCount)
-			c.recorder.Eventf(pod, v1.EventTypeWarning, "PreviousPodWasOOMKilled", "The previous instance of the container '%s' (%s) was OOMKilled", s.Name, s.ContainerID)
+			c.recorder.Eventf(pod, v1.EventTypeWarning, "PreviousContainerWasOOMKilled", "The previous instance of the container '%s' (%s) was OOMKilled", s.Name, s.ContainerID)
 			ProcessedContainerUpdates.WithLabelValues("oomkilled_event_sent").Inc()
 		} else {
 			glog.V(1).Infof("Restart count hasn't changed for '%s' in '%s/%s'", s.Name, pod.Namespace, pod.Name)

--- a/src/controller/controller_test.go
+++ b/src/controller/controller_test.go
@@ -93,7 +93,7 @@ func TestEvaluatingPodStatusOnOOMKilled(t *testing.T) {
 		dummyEvent{
 			Obj:       p,
 			EventType: v1.EventTypeWarning,
-			Reason:    "PreviousPodWasOOMKilled",
+			Reason:    "PreviousContainerWasOOMKilled",
 			Message:   "The previous instance of the container 'our-container' (our-container-1234) was OOMKilled",
 		},
 	}, recorder.Events)


### PR DESCRIPTION
The README already stated that the reason for the event was
'PreviousContainerWasOOMKilled' which actually reflects what happened.
The code however still sent an event with reason 'PreviousPodWasOOMKilled',
which is not true, since in the reported case a container (within a pod) is
OOMKilled and subsequently restarted.