### PR TITLE
use container started events instead of pod updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,15 @@ it was previously out-of-memory killed.
 
 ## Design
 
-The Controller listens to the Kubernetes API for Pod changes. Everytime a Pod change is received,
-it checks the status of every container and searches for those claiming they were OOMKilled previously.
-If the `RestartCount` for a container is higher than the one we have in our local state, a Kubernetes
-Event is generated as `Warning` with the reason `PreviousContainerWasOOMKilled`.
+The Controller listens to the Kubernetes API for new Events and changes to
+Events. Every time a notification regarding an Event is received it checks
+whether this Event refers to a "ContainerStarted" event, based on the `Reason`
+for the Event and the `Kind` of the involved object. If this is the case
+and the Event constitutes a change (meaning it is not a not-changing update,
+which happens when the resync, that is executed every two minutes, is run) it checks
+the underlying Pod resource. Should the `LastTerminationState` of the Pod refer to
+an OOM kill the controller will emit a Kubernetes Event with a level of `Warning`
+and a reason of `PreviousContainerWasOOMKilled`.
 
 ## Usage
 

--- a/src/controller/controller.go
+++ b/src/controller/controller.go
@@ -102,6 +102,14 @@ func isSameEventOccurrence(g *eventUpdateGroup) bool {
 		g.oldEvent.Count == g.newEvent.Count)
 }
 
+func isSimilarEnoughEvent(a, b *core.Event) bool {
+	return (a.InvolvedObject == b.InvolvedObject &&
+		a.Reason == b.Reason &&
+		a.Count == b.Count &&
+		a.FirstTimestamp == b.FirstTimestamp &&
+		a.LastTimestamp == b.LastTimestamp)
+}
+
 func (c *Controller) evaluateEvent(event *core.Event) {
 	glog.V(2).Infof("got event %s/%s (count: %d), reason: %s, involved object: %s", event.ObjectMeta.Namespace, event.ObjectMeta.Name, event.Count, event.Reason, event.InvolvedObject.Kind)
 	if !isContainerStartedEvent(event) {
@@ -121,7 +129,7 @@ func (c *Controller) evaluateEventUpdate(eventUpdate *eventUpdateGroup) {
 		glog.V(4).Infof("No old event present for event %s/%s (count: %d), reason: %s, involved object: %s, skipping processing", event.ObjectMeta.Namespace, event.ObjectMeta.Name, event.Count, event.Reason, event.InvolvedObject.Kind)
 		return
 	}
-	if eventUpdate.oldEvent == eventUpdate.newEvent {
+	if isSimilarEnoughEvent(eventUpdate.oldEvent, eventUpdate.newEvent) {
 		glog.V(4).Infof("Event %s/%s (count: %d), reason: %s, involved object: %s, did not change: skipping processing", event.ObjectMeta.Namespace, event.ObjectMeta.Name, event.Count, event.Reason, event.InvolvedObject.Kind)
 		return
 	}

--- a/src/controller/controller.go
+++ b/src/controller/controller.go
@@ -75,7 +75,7 @@ func NewController(stop chan struct{}) *Controller {
 // Run is the main loop that processes Kubernetes Pod changes
 func (c *Controller) Run() error {
 	c.k8sFactory.Start(c.stopCh)
-	c.k8sFactory.WaitForCacheSync(nil)
+	c.k8sFactory.WaitForCacheSync(c.Stop)
 
 	for {
 		select {

--- a/src/controller/controller.go
+++ b/src/controller/controller.go
@@ -1,6 +1,7 @@
 package controller
 
 import (
+	"reflect"
 	"time"
 
 	"github.com/golang/glog"
@@ -102,14 +103,6 @@ func isSameEventOccurrence(g *eventUpdateGroup) bool {
 		g.oldEvent.Count == g.newEvent.Count)
 }
 
-func isSimilarEnoughEvent(a, b *core.Event) bool {
-	return (a.InvolvedObject == b.InvolvedObject &&
-		a.Reason == b.Reason &&
-		a.Count == b.Count &&
-		a.FirstTimestamp == b.FirstTimestamp &&
-		a.LastTimestamp == b.LastTimestamp)
-}
-
 func (c *Controller) evaluateEvent(event *core.Event) {
 	glog.V(2).Infof("got event %s/%s (count: %d), reason: %s, involved object: %s", event.ObjectMeta.Namespace, event.ObjectMeta.Name, event.Count, event.Reason, event.InvolvedObject.Kind)
 	if !isContainerStartedEvent(event) {
@@ -129,7 +122,7 @@ func (c *Controller) evaluateEventUpdate(eventUpdate *eventUpdateGroup) {
 		glog.V(4).Infof("No old event present for event %s/%s (count: %d), reason: %s, involved object: %s, skipping processing", event.ObjectMeta.Namespace, event.ObjectMeta.Name, event.Count, event.Reason, event.InvolvedObject.Kind)
 		return
 	}
-	if isSimilarEnoughEvent(eventUpdate.oldEvent, eventUpdate.newEvent) {
+	if reflect.DeepEqual(eventUpdate.oldEvent, eventUpdate.newEvent) {
 		glog.V(4).Infof("Event %s/%s (count: %d), reason: %s, involved object: %s, did not change: skipping processing", event.ObjectMeta.Namespace, event.ObjectMeta.Name, event.Count, event.Reason, event.InvolvedObject.Kind)
 		return
 	}

--- a/src/controller/controller.go
+++ b/src/controller/controller.go
@@ -15,7 +15,7 @@ import (
 
 const (
 	// informerSyncMinute defines how often the cache is synced from Kubernetes
-	informerSyncMinute = 3
+	informerSyncMinute = 2
 )
 
 // Controller is a controller that listens on Pod changes and create Kubernetes Events

--- a/src/controller/controller_test.go
+++ b/src/controller/controller_test.go
@@ -8,8 +8,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
-	"k8s.io/api/core/v1"
-	corev1_api "k8s.io/api/core/v1"
+	core "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
@@ -20,65 +19,36 @@ func init() {
 	}
 }
 
-func TestSetNewContainerRestart(t *testing.T) {
+func TestEvaluatingUninterestingEvent(t *testing.T) {
 	c := controller()
+	recorder := dummyRecorder()
+	c.recorder = recorder
+	event := event("Scaled", "ReplicaSet", "my-namespace", "rs-247484f")
+	// p := pod("OOMKilled", 1, c.startTime.Add(120))
+	c.evaluateEvent(event)
 
-	changed := c.setRestartCount("pod-1", "container-1", 1)
-
-	assert.Equal(t, len(c.podState), 1)
-	assert.Equal(t, changed, true)
+	assert.Equal(t, len(recorder.Events), 0)
 }
 
-func TestSetExistingContainerRestart(t *testing.T) {
+func TestEvaluatingInterestingEvent(t *testing.T) {
 	c := controller()
+	recorder := dummyRecorder()
+	c.recorder = recorder
+	event := event(startedEvent, podKind, "my-namespace", "rs-247484f")
+	// p := pod("OOMKilled", 1, c.startTime.Add(120))
+	c.evaluateEvent(event)
 
-	c.setRestartCount("pod-1", "container-1", 1)
-	changed := c.setRestartCount("pod-1", "container-1", 1)
-
-	assert.Equal(t, len(c.podState), 1)
-	assert.Equal(t, changed, false)
-}
-
-func TestSetMultipleNewContainerRestart(t *testing.T) {
-	c := controller()
-
-	changed1 := c.setRestartCount("pod-1", "container-1", 1)
-	changed2 := c.setRestartCount("pod-1", "container-1", 2)
-	changed3 := c.setRestartCount("pod-1", "container-1", 1)
-
-	assert.Equal(t, len(c.podState), 1)
-	assert.Equal(t, changed1, true)
-	assert.Equal(t, changed2, true)
-	assert.Equal(t, changed3, false)
-}
-
-func TestSetTwoContainerRestart(t *testing.T) {
-	c := controller()
-
-	changed1 := c.setRestartCount("pod-1", "container-1", 3)
-	changed2 := c.setRestartCount("pod-1", "container-2", 9)
-
-	assert.Equal(t, c.podState, map[string]map[string]int32(map[string]map[string]int32{"pod-1": map[string]int32{"container-2": 9, "container-1": 3}}))
-	assert.Equal(t, changed1, true)
-	assert.Equal(t, changed2, true)
-}
-
-func TestDeletePodState(t *testing.T) {
-	c := controller()
-
-	c.setRestartCount("pod-1", "container-1", 1)
-	assert.Equal(t, len(c.podState), 1)
-
-	c.deletePodState("pod-1")
-	assert.Equal(t, len(c.podState), 0)
+	assert.Equal(t, len(recorder.Events), 0)
 }
 
 func TestEvaluatingPodStatusOnNotOOMKilled(t *testing.T) {
 	c := controller()
+	recorder := dummyRecorder()
+	c.recorder = recorder
 	p := pod("", 1, c.startTime.Add(120))
 	c.evaluatePodStatus(p)
 
-	assert.Equal(t, len(c.podState), 0)
+	assert.Equal(t, len(recorder.Events), 0)
 }
 
 func TestEvaluatingPodStatusOnOOMKilled(t *testing.T) {
@@ -88,11 +58,10 @@ func TestEvaluatingPodStatusOnOOMKilled(t *testing.T) {
 	p := pod("OOMKilled", 1, c.startTime.Add(120))
 	c.evaluatePodStatus(p)
 
-	assert.Equal(t, 1, len(c.podState))
 	assert.Equal(t, []dummyEvent{
 		dummyEvent{
 			Obj:       p,
-			EventType: v1.EventTypeWarning,
+			EventType: core.EventTypeWarning,
 			Reason:    "PreviousContainerWasOOMKilled",
 			Message:   "The previous instance of the container 'our-container' (our-container-1234) was OOMKilled",
 		},
@@ -137,15 +106,26 @@ func dummyRecorder() *dummyEventRecorder {
 	return &dummyEventRecorder{}
 }
 
-func pod(terminationReason string, restartCount int32, finishedAt time.Time) *corev1_api.Pod {
-	terminatedState := corev1_api.ContainerStateTerminated{
+func event(reason, kind, namespace, name string) *core.Event {
+	return &core.Event{
+		Reason: reason,
+		InvolvedObject: core.ObjectReference{
+			Kind:      kind,
+			Namespace: namespace,
+			Name:      name,
+		},
+	}
+}
+
+func pod(terminationReason string, restartCount int32, finishedAt time.Time) *core.Pod {
+	terminatedState := core.ContainerStateTerminated{
 		Reason:     terminationReason,
 		FinishedAt: metav1.NewTime(finishedAt),
 	}
-	containerStatus := corev1_api.ContainerStatus{
+	containerStatus := core.ContainerStatus{
 		ContainerID: "our-container-1234",
 		Name:        "our-container",
-		LastTerminationState: corev1_api.ContainerState{
+		LastTerminationState: core.ContainerState{
 			Terminated: &terminatedState,
 		},
 		RestartCount: restartCount,
@@ -154,10 +134,10 @@ func pod(terminationReason string, restartCount int32, finishedAt time.Time) *co
 		Name:      "our-pod",
 		Namespace: "our-pod-namespace",
 	}
-	return &corev1_api.Pod{
+	return &core.Pod{
 		ObjectMeta: objMeta,
-		Status: corev1_api.PodStatus{
-			ContainerStatuses: []corev1_api.ContainerStatus{
+		Status: core.PodStatus{
+			ContainerStatuses: []core.ContainerStatus{
 				containerStatus,
 			},
 		},

--- a/src/controller/controller_test.go
+++ b/src/controller/controller_test.go
@@ -24,7 +24,6 @@ func TestEvaluatingUninterestingEvent(t *testing.T) {
 	recorder := dummyRecorder()
 	c.recorder = recorder
 	event := event("Scaled", "ReplicaSet", "my-namespace", "rs-247484f")
-	// p := pod("OOMKilled", 1, c.startTime.Add(120))
 	c.evaluateEvent(event)
 
 	assert.Equal(t, len(recorder.Events), 0)
@@ -35,7 +34,6 @@ func TestEvaluatingInterestingEvent(t *testing.T) {
 	recorder := dummyRecorder()
 	c.recorder = recorder
 	event := event(startedEvent, podKind, "my-namespace", "rs-247484f")
-	// p := pod("OOMKilled", 1, c.startTime.Add(120))
 	c.evaluateEvent(event)
 
 	assert.Equal(t, len(recorder.Events), 0)

--- a/src/util/cli.go
+++ b/src/util/cli.go
@@ -33,6 +33,7 @@ func InstallSignalHandler(stop chan struct{}) {
 	go func() {
 		<-sigs
 		stop <- struct{}{}
+		close(stop)
 	}()
 }
 

--- a/src/util/kubernetes.go
+++ b/src/util/kubernetes.go
@@ -6,6 +6,7 @@ import (
 	"github.com/golang/glog"
 
 	"k8s.io/client-go/kubernetes"
+	listersV1 "k8s.io/client-go/listers/core/v1"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/oidc" // needed for local development with .kube/config
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
@@ -31,4 +32,8 @@ func Clientset() kubernetes.Interface {
 	}
 
 	return client
+}
+
+type PodLister interface {
+	Pods(namespace string) listersV1.PodNamespaceLister
 }


### PR DESCRIPTION
This should eliminate the need of keeping internal state by reacting
on container started events for pods instead.