### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ Example Clusterrole:
         verbs:
           - create
           - patch
+          - list
+          - watch
 
 Run this controller on Kubernetes with the following commands:
 


### PR DESCRIPTION
Fix missing permissions in `ClusterRole`.
Without the generator throws errors:

```
pkg/mod/k8s.io/client-go@v10.0.0+incompatible/tools/cache/reflector.go:95: Failed to list *v1.Event: events is forbidden: User "system:servicea │
│ ccount:kube-system:kubernetes-oom-event-generator" cannot list resource "events" in API group "" at the cluster scope

E1114 10:05:32.679053       1 reflector.go:251] pkg/mod/k8s.io/client-go@v10.0.0+incompatible/tools/cache/reflector.go:95: Failed to watch *v1.Event: unknown (get events)
```