### PR TITLE
update image versions and remove deprecated go build flag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.13.0
+FROM golang:1.17.0
 COPY . /src/
 WORKDIR /src/
 
@@ -11,6 +11,6 @@ RUN make clean \
   && make test \
   && make
 
-FROM ubuntu:xenial
+FROM ubuntu:focal
 COPY --from=0 /src/kubernetes-oom-event-generator /usr/bin/kubernetes-oom-event-generator
 ENTRYPOINT ["/usr/bin/kubernetes-oom-event-generator"]

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ BRANCH = $(shell git rev-parse --abbrev-ref HEAD)
 all: kubernetes-oom-event-generator
 
 kubernetes-oom-event-generator:
-	go build -i
+	go build
 
 clean:
 	go clean ./...


### PR DESCRIPTION
No practical changes. Just using more recent images to avoid running unsupported software in production.